### PR TITLE
Fix dom warning when wrapper for Overlay component haven't mounted yet

### DIFF
--- a/src/components/Overlay/Overlay.js
+++ b/src/components/Overlay/Overlay.js
@@ -6,7 +6,7 @@ import as from "../../enhancers/as";
 import Hidden from "../Hidden";
 
 class Component extends React.Component {
-  state = {};
+  state = {wrapper: null};
 
   componentDidMount() {
     const wrapper = document.createElement("div");
@@ -15,7 +15,9 @@ class Component extends React.Component {
   }
 
   componentWillUnmount() {
-    document.body.removeChild(this.state.wrapper);
+    if (this.state.wrapper) {
+      document.body.removeChild(this.state.wrapper);
+    }
   }
 
   render() {


### PR DESCRIPTION
Not checking if the `wrapper` state for the `Overlay` component is mounted before removing it when it unmounts causes in some edge cases this warning:
`TypeError: Failed to execute 'removeChild' on 'Node': parameter 1 is not of type 'Node'.
`
It's weird but seems like React call `componentWillUnMount` even when the component didn't have the chance to be mounted yet.